### PR TITLE
Fix: should load settings with empty/null value

### DIFF
--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -40,7 +40,7 @@ export class AzureAppConfigurationImpl extends Map<string, unknown> implements A
             });
 
             for await (const setting of settings) {
-                if (setting.key && setting.value) {
+                if (setting.key) {
                     const [key, value] = await this.processAdapters(setting);
                     const trimmedKey = this.keyWithPrefixesTrimmed(key);
                     keyValues.push([trimmedKey, value]);

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -41,6 +41,24 @@ const mockedKVs = [{
     tags: {},
     etag: 'GdmsLWq3mFjFodVEXUYRmvFr3l_qRiKAW_KdpFbxZKk',
     isReadOnly: false
+}, {
+    value: null,
+    key: 'KeyForNullValue',
+    label: '',
+    contentType: '',
+    lastModified: '2023-05-04T04:32:56.000Z',
+    tags: {},
+    etag: 'GdmsLWq3mFjFodVEXUYRmvFr3l_qRiKAW_KdpFbxZKk',
+    isReadOnly: false
+}, {
+    value: "",
+    key: 'KeyForEmptyValue',
+    label: '',
+    contentType: '',
+    lastModified: '2023-05-04T04:32:56.000Z',
+    tags: {},
+    etag: 'GdmsLWq3mFjFodVEXUYRmvFr3l_qRiKAW_KdpFbxZKk',
+    isReadOnly: false
 }];
 
 describe("load", function () {
@@ -120,5 +138,15 @@ describe("load", function () {
         expect(settings.get("fontSize")).eq("40");
         expect(settings.has("Key")).eq(true);
         expect(settings.get("Key")).eq("TestValue");
+    });
+
+    it("should support null/empty value", async () => {
+        const connectionString = createMockedConnectionString();
+        const settings = await load(connectionString);
+        expect(settings).not.undefined;
+        expect(settings.has("KeyForNullValue")).eq(true);
+        expect(settings.get("KeyForNullValue")).eq(null);
+        expect(settings.has("KeyForEmptyValue")).eq(true);
+        expect(settings.get("KeyForEmptyValue")).eq("");
     });
 })


### PR DESCRIPTION
This PR fixes the bug that config settings with empty/null value are not included when calling `load` api.

Verified that in Portal, response of Rest API, SDKs, .NET Provider, they all include settings with null/empty values. So here we should have consistent behavior.


PS:
How to create empty/null value from portal?
- empty value `""`: create a config and leave the value input box empty.
- null value: in Advanced Edit, explicitly change the line of value to `"value": null`.