### PR TITLE
Put declaration file under types folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,6 +400,7 @@ FodyWeavers.xsd
 # bundled folder
 dist/
 dist-esm/
+types/
 
 # dotenv
 .env

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The JavaScript configuration provider for Azure App Configuration",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
-  "types": "dist/index.d.ts",
+  "types": "types/index.d.ts",
   "files": [
     "dist/**/*.js",
     "dist/**/*.map",
@@ -12,6 +12,7 @@
     "dist-esm/**/*.js",
     "dist-esm/**/*.map",
     "dist-esm/**/*.d.ts",
+    "types/**/*.d.ts",
     "LICENSE",
     "README.md"
   ],
@@ -19,7 +20,7 @@
     "build": "npm run clean && npm run build-cjs && npm run build-esm",
     "build-cjs": "rollup --config",
     "build-esm": "tsc -p ./",
-    "clean": "rimraf dist dist-esm",
+    "clean": "rimraf dist dist-esm types",
     "dev": "rollup --config --watch",
     "lint": "eslint src/ test/",
     "fix-lint": "eslint src/ test/ --fix",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -29,7 +29,7 @@ export default [
   },
   {
     input: "src/index.ts",
-    output: [{ file: "dist/index.d.ts", format: "es" }],
+    output: [{ file: "types/index.d.ts", format: "es" }],
     plugins: [dts()],
   },
 ];


### PR DESCRIPTION
Previously .d.ts file is generated in `dist` folder. Now following other SDK libs, moving it to a dedicated `types` folder.