### PR TITLE
forbid wildcard in label filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "rollup-plugin-dts": "^5.3.0",
         "sinon": "^15.2.0",
         "tslib": "^2.6.0",
-        "typescript": "^5.1.6"
+        "typescript": "^5.1.6",
+        "uuid": "^9.0.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -208,6 +209,14 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@azure/identity/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@azure/keyvault-secrets": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@azure/keyvault-secrets/-/keyvault-secrets-4.7.0.tgz",
@@ -270,6 +279,14 @@
       },
       "engines": {
         "node": "10 || 12 || 14 || 16 || 18"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3379,9 +3396,14 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -3656,6 +3678,13 @@
         "stoppable": "^1.1.0",
         "tslib": "^2.2.0",
         "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@azure/keyvault-secrets": {
@@ -3705,6 +3734,13 @@
         "@azure/msal-common": "13.3.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@babel/code-frame": {
@@ -5947,9 +5983,10 @@
       }
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "rollup-plugin-dts": "^5.3.0",
     "sinon": "^15.2.0",
     "tslib": "^2.6.0",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "uuid": "^9.0.1"
   },
   "dependencies": {
     "@azure/app-configuration": "^1.4.1",

--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -46,7 +46,7 @@ export class AzureAppConfigurationImpl extends Map<string, unknown> implements A
         const keyValues: [key: string, value: unknown][] = [];
 
         // validate selectors
-        const selectors = validatedSelectors(this.options?.selectors);
+        const selectors = getValidSelectors(this.options?.selectors);
 
         for (const selector of selectors) {
             const listOptions: ListConfigurationSettingsOptions = {
@@ -109,7 +109,7 @@ export class AzureAppConfigurationImpl extends Map<string, unknown> implements A
     }
 }
 
-function validatedSelectors(selectors?: { keyFilter: string, labelFilter?: string }[]) {
+function getValidSelectors(selectors?: { keyFilter: string, labelFilter?: string }[]) {
     if (!selectors || selectors.length === 0) {
         // Default selector: key: *, label: \0
         return [{ keyFilter: KeyFilter.Any, labelFilter: LabelFilter.Null }];
@@ -117,7 +117,7 @@ function validatedSelectors(selectors?: { keyFilter: string, labelFilter?: strin
     return selectors.map(selectorCandidate => {
         const selector = { ...selectorCandidate };
         if (!selector.keyFilter) {
-            throw new Error("Key filters cannot be empty.");
+            throw new Error("Key filter cannot be null or empty.");
         }
         if (!selector.labelFilter) {
             selector.labelFilter = LabelFilter.Null;

--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -44,7 +44,10 @@ export class AzureAppConfigurationImpl extends Map<string, unknown> implements A
 
     public async load() {
         const keyValues: [key: string, value: unknown][] = [];
-        const selectors = this.options?.selectors ?? [{ keyFilter: KeyFilter.Any, labelFilter: LabelFilter.Null }];
+
+        // validate selectors
+        const selectors = validatedSelectors(this.options?.selectors);
+
         for (const selector of selectors) {
             const listOptions: ListConfigurationSettingsOptions = {
                 keyFilter: selector.keyFilter,
@@ -104,4 +107,24 @@ export class AzureAppConfigurationImpl extends Map<string, unknown> implements A
         headers[CorrelationContextHeaderName] = this.correlationContextHeader;
         return headers;
     }
+}
+
+function validatedSelectors(selectors?: { keyFilter: string, labelFilter?: string }[]) {
+    if (!selectors || selectors.length === 0) {
+        // Default selector: key: *, label: \0
+        return [{ keyFilter: KeyFilter.Any, labelFilter: LabelFilter.Null }];
+    }
+    return selectors.map(selectorCandidate => {
+        const selector = { ...selectorCandidate };
+        if (!selector.keyFilter) {
+            throw new Error("Key filters cannot be empty.");
+        }
+        if (!selector.labelFilter) {
+            selector.labelFilter = LabelFilter.Null;
+        }
+        if (selector.labelFilter.includes("*") || selector.labelFilter.includes(",")) {
+            throw new Error("The characters '*' and ',' are not supported in label filters.");
+        }
+        return selector;
+    });
 }

--- a/src/AzureAppConfigurationOptions.ts
+++ b/src/AzureAppConfigurationOptions.ts
@@ -9,10 +9,23 @@ export const MaxRetryDelayInMs = 60000;
 
 export interface AzureAppConfigurationOptions {
     /**
-     * Selectors used to control what key-values are retrieved from Azure App Configuration.
+     * Specify what key-values to include in the configuration provider.  include multiple sets of key-values
      *
-     * @property keyFilter: A filter that determines the set of keys that are included in the configuration provider, cannot be omitted.
-     * @property labelFilter: A filter that determines what label to use when selecting key-values for the the configuration provider, omitted for no label.
+     * @property keyFilter:
+     * The key filter to apply when querying Azure App Configuration for key-values.
+     * An asterisk `*` can be added to the end to return all key-values whose key begins with the key filter.
+     * e.g. key filter `abc*` returns all key-values whose key starts with `abc`.
+     * A comma `,` can be used to select multiple key-values. Comma separated filters must exactly match a key to select it.
+     * Using asterisk to select key-values that begin with a key filter while simultaneously using comma separated key filters is not supported.
+     * E.g. the key filter `abc*,def` is not supported. The key filters `abc*` and `abc,def` are supported.
+     * For all other cases the characters: asterisk `*`, comma `,`, and backslash `\` are reserved. Reserved characters must be escaped using a backslash (\).
+     * e.g. the key filter `a\\b\,\*c*` returns all key-values whose key starts with `a\b,*c`.
+     *
+     * @property labelFilter:
+     * The label filter to apply when querying Azure App Configuration for key-values.
+     * By default, the "null label" will be used, matching key-values without a label.
+     * The characters asterisk `*` and comma `,` are not supported.
+     * Backslash `\` character is reserved and must be escaped using another backslash `\`.
      */
     selectors?: { keyFilter: string, labelFilter?: string }[];
     trimKeyPrefixes?: string[];

--- a/src/AzureAppConfigurationOptions.ts
+++ b/src/AzureAppConfigurationOptions.ts
@@ -8,7 +8,13 @@ export const MaxRetries = 2;
 export const MaxRetryDelayInMs = 60000;
 
 export interface AzureAppConfigurationOptions {
-    selectors?: { keyFilter: string, labelFilter: string }[];
+    /**
+     * Selectors used to control what key-values are retrieved from Azure App Configuration.
+     *
+     * @property keyFilter: A filter that determines the set of keys that are included in the configuration provider, cannot be omitted.
+     * @property labelFilter: A filter that determines what label to use when selecting key-values for the the configuration provider, omitted for no label.
+     */
+    selectors?: { keyFilter: string, labelFilter?: string }[];
     trimKeyPrefixes?: string[];
     clientOptions?: AppConfigurationClientOptions;
     keyVaultOptions?: AzureAppConfigurationKeyVaultOptions;


### PR DESCRIPTION
This PR:
- forbid wildcards by throwing errors if `*` or `,` detected in label filters. (because we cannot handle settings with the same key but different labels"
- update test utils and add corresponding test cases.
