### PR TITLE
update @azure/app-configuration to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-preview",
       "license": "MIT",
       "dependencies": {
-        "@azure/app-configuration": "^1.4.1",
+        "@azure/app-configuration": "^1.5.0",
         "@azure/identity": "^3.3.2",
         "@azure/keyvault-secrets": "^4.7.0"
       },
@@ -57,20 +57,34 @@
       }
     },
     "node_modules/@azure/app-configuration": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@azure/app-configuration/-/app-configuration-1.4.1.tgz",
-      "integrity": "sha512-9vLmveQR3U5DmMGkXU6fQzG7vf+GWMM+1g6zf/5Ro81dOP0R2fPDdBOd4Edg2pZpuswsf2t6QE+wo/oCeaVLZA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/app-configuration/-/app-configuration-1.5.0.tgz",
+      "integrity": "sha512-YlXwWc/weDFCk12arPkfskXDGxDaSyAA7JaztSVQ0y/IS7GFYqmIj3RTKbsNUSSuGLrKqcxwJ7y3vY9UmHgsdA==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
         "@azure/core-client": "^1.5.0",
-        "@azure/core-http-compat": "^1.2.0",
+        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-lro": "^2.5.1",
         "@azure/core-paging": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.6.0",
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.1.0",
         "@azure/logger": "^1.0.0",
         "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/app-configuration/node_modules/@azure/core-http-compat": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.0.1.tgz",
+      "integrity": "sha512-xpQZz/q7E0jSW4rckrTo2mDFDQgo6I69hBU4voMQi7REi6JRW5a+KfVkbJCFCWnkFmP6cAJ0IbuudTdf/MEBOQ==",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.4",
+        "@azure/core-client": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.3.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3585,20 +3599,33 @@
       }
     },
     "@azure/app-configuration": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@azure/app-configuration/-/app-configuration-1.4.1.tgz",
-      "integrity": "sha512-9vLmveQR3U5DmMGkXU6fQzG7vf+GWMM+1g6zf/5Ro81dOP0R2fPDdBOd4Edg2pZpuswsf2t6QE+wo/oCeaVLZA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/app-configuration/-/app-configuration-1.5.0.tgz",
+      "integrity": "sha512-YlXwWc/weDFCk12arPkfskXDGxDaSyAA7JaztSVQ0y/IS7GFYqmIj3RTKbsNUSSuGLrKqcxwJ7y3vY9UmHgsdA==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
         "@azure/core-client": "^1.5.0",
-        "@azure/core-http-compat": "^1.2.0",
+        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-lro": "^2.5.1",
         "@azure/core-paging": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.6.0",
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.1.0",
         "@azure/logger": "^1.0.0",
         "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "@azure/core-http-compat": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.0.1.tgz",
+          "integrity": "sha512-xpQZz/q7E0jSW4rckrTo2mDFDQgo6I69hBU4voMQi7REi6JRW5a+KfVkbJCFCWnkFmP6cAJ0IbuudTdf/MEBOQ==",
+          "requires": {
+            "@azure/abort-controller": "^1.0.4",
+            "@azure/core-client": "^1.3.0",
+            "@azure/core-rest-pipeline": "^1.3.0"
+          }
+        }
       }
     },
     "@azure/core-auth": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "uuid": "^9.0.1"
   },
   "dependencies": {
-    "@azure/app-configuration": "^1.4.1",
+    "@azure/app-configuration": "^1.5.0",
     "@azure/identity": "^3.3.2",
     "@azure/keyvault-secrets": "^4.7.0"
   }


### PR DESCRIPTION
As a follow-up action to fix the bug described in https://github.com/Azure/azure-sdk-for-js/issues/27607

For a configuration setting with no label,
Before the fix, it has a property `label: null`, which doesn't match the type definition `label:? string`. 
After the fix, it has no property `label`, and accessing the property `setting.label` returns undefined, which is as expected. 