### PR TITLE
update doc comments per TSDoc standard

### DIFF
--- a/src/AzureAppConfigurationOptions.ts
+++ b/src/AzureAppConfigurationOptions.ts
@@ -11,12 +11,16 @@ export const MaxRetryDelayInMs = 60000;
 export interface AzureAppConfigurationOptions {
     /**
      * Specify what key-values to include in the configuration provider.
+     *
+     * @remarks
      * If no selectors are specified then all key-values with no label will be included.
      */
     selectors?: SettingSelector[];
 
     /**
      * Specifies prefixes to be trimmed from the keys of all key-values retrieved from Azure App Configuration.
+     *
+     * @remarks
      * This is useful when you want to remove a common prefix from all keys to avoid repetition.
      * The provided prefixes will be sorted in descending order and the longest matching prefix will be trimmed first.
      */

--- a/src/load.ts
+++ b/src/load.ts
@@ -16,6 +16,7 @@ const MinDelayForUnhandedError: number = 5000; // 5 seconds
  * @param options  Optional parameters.
  */
 export async function load(connectionString: string, options?: AzureAppConfigurationOptions): Promise<AzureAppConfiguration>;
+
 /**
  * Loads the data from Azure App Configuration service and returns an instance of AzureAppConfiguration.
  * @param endpoint  The URL to the App Configuration store.
@@ -23,6 +24,7 @@ export async function load(connectionString: string, options?: AzureAppConfigura
  * @param options  Optional parameters.
  */
 export async function load(endpoint: URL | string, credential: TokenCredential, options?: AzureAppConfigurationOptions): Promise<AzureAppConfiguration>;
+
 export async function load(
     connectionStringOrEndpoint: string | URL,
     credentialOrOptions?: TokenCredential | AzureAppConfigurationOptions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,43 +2,50 @@
 // Licensed under the MIT license.
 
 /**
- * SettingSelector is used to select key-values from Azure App Configuration.
- * It is used to filter key-values based on keys and labels.
- * 
- * @property keyFilter:
- * The key filter to apply when querying Azure App Configuration for key-values.
- * An asterisk `*` can be added to the end to return all key-values whose key begins with the key filter.
- * e.g. key filter `abc*` returns all key-values whose key starts with `abc`.
- * A comma `,` can be used to select multiple key-values. Comma separated filters must exactly match a key to select it.
- * Using asterisk to select key-values that begin with a key filter while simultaneously using comma separated key filters is not supported.
- * E.g. the key filter `abc*,def` is not supported. The key filters `abc*` and `abc,def` are supported.
- * For all other cases the characters: asterisk `*`, comma `,`, and backslash `\` are reserved. Reserved characters must be escaped using a backslash (\).
- * e.g. the key filter `a\\b\,\*c*` returns all key-values whose key starts with `a\b,*c`.
- *
- * @property labelFilter:
- * The label filter to apply when querying Azure App Configuration for key-values.
- * By default, the "null label" will be used, matching key-values without a label.
- * The characters asterisk `*` and comma `,` are not supported.
- * Backslash `\` character is reserved and must be escaped using another backslash `\`.
+ * SettingSelector is used to select key-values from Azure App Configuration based on keys and labels.
  */
-export type SettingSelector = { keyFilter: string, labelFilter?: string };
+export type SettingSelector = {
+    /**
+     * The key filter to apply when querying Azure App Configuration for key-values.
+     *
+     * @remarks
+     * An asterisk `*` can be added to the end to return all key-values whose key begins with the key filter.
+     * e.g. key filter `abc*` returns all key-values whose key starts with `abc`.
+     * A comma `,` can be used to select multiple key-values. Comma separated filters must exactly match a key to select it.
+     * Using asterisk to select key-values that begin with a key filter while simultaneously using comma separated key filters is not supported.
+     * E.g. the key filter `abc*,def` is not supported. The key filters `abc*` and `abc,def` are supported.
+     * For all other cases the characters: asterisk `*`, comma `,`, and backslash `\` are reserved. Reserved characters must be escaped using a backslash (\).
+     * e.g. the key filter `a\\b\,\*c*` returns all key-values whose key starts with `a\b,*c`.
+     */
+    keyFilter: string,
+
+    /**
+     * The label filter to apply when querying Azure App Configuration for key-values.
+     *
+     * @remarks
+     * By default, the "null label" will be used, matching key-values without a label.
+     * The characters asterisk `*` and comma `,` are not supported.
+     * Backslash `\` character is reserved and must be escaped using another backslash `\`.
+     */
+    labelFilter?: string
+};
 
 /**
  * KeyFilter is used to filter key-values based on keys.
- *
- * @property Any:
- * Matches all key-values.
  */
 export enum KeyFilter {
+    /**
+     * Matches all key-values.
+     */
     Any = "*"
 }
 
 /**
  * LabelFilter is used to filter key-values based on labels.
- *
- * @property Null:
- * Matches key-values without a label.
  */
 export enum LabelFilter {
+    /**
+     * Matches key-values without a label.
+     */
     Null = "\0"
 }


### PR DESCRIPTION
This PR follows the [TSDoc ](https://tsdoc.org/pages/tags/remarks/)standard to update the doc comments, providing better intellisense.
- optimize for type SettingSelector, adding comments for keyFilter and labelFilter respectively.
- using `@remarks` tag