### PR TITLE
Run test cases in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dev": "rollup --config --watch",
     "lint": "eslint src/ test/",
     "fix-lint": "eslint src/ test/ --fix",
-    "test": "mocha out/test/*.test.{js,cjs,mjs} --timeout 15000"
+    "test": "mocha out/test/*.test.{js,cjs,mjs} --parallel"
   },
   "repository": {
     "type": "git",

--- a/test/clientOptions.test.ts
+++ b/test/clientOptions.test.ts
@@ -27,6 +27,8 @@ class HttpRequestCountPolicy {
 }
 
 describe("custom client options", function () {
+    this.timeout(15000);
+
     const fakeEndpoint = "https://azure.azconfig.io";
     beforeEach(() => {
         // Thus here mock it to reply 500, in which case the retry mechanism works.

--- a/test/requestTracing.test.ts
+++ b/test/requestTracing.test.ts
@@ -22,6 +22,8 @@ class HttpRequestHeadersPolicy {
 }
 
 describe("request tracing", function () {
+    this.timeout(15000);
+
     const fakeEndpoint = "https://127.0.0.1"; // sufficient to test the request it sends out
     const headerPolicy = new HttpRequestHeadersPolicy();
     const position: "perCall" | "perRetry" = "perCall";


### PR DESCRIPTION
Now we have multiple test cases with a reasonable delay of 5s~10s.  Run them in [parallel ](https://mochajs.org/#parallel-tests)will speed up the CI. 

This PR:
- enables parallel mode
- set suite-level timeout instead of global

```log
  custom client options
    ✔ should retry 2 times by default (5013ms)
    ✔ should override default retry options (10024ms)
    ✔ should retry on DNS failure (5005ms)


  request tracing
    ✔ should have correct user agent prefix (5004ms)
    ✔ should have request type in correlation-context header (5003ms)
    ✔ should have key vault tag in correlation-context header (5015ms)
    ✔ should detect env in correlation-context header (5011ms)
    ✔ should detect host type in correlation-context header (5002ms)
    ✔ should disable request tracing when AZURE_APP_CONFIGURATION_TRACING_DISABLED is true (10009ms)
```



Before
```
  29 passing (55s)
```

After
```
  29 passing (36s)
```