### PR TITLE
Assert error messages and increase timeout for tests

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -48,7 +48,7 @@ export async function load(
                 endpoint = new URL(endpoint);
             } catch (error) {
                 if (error.code === "ERR_INVALID_URL") {
-                    throw new Error("Invalid Endpoint URL.", { cause: error });
+                    throw new Error("Invalid endpoint URL.", { cause: error });
                 } else {
                     throw error;
                 }

--- a/test/keyvault.test.ts
+++ b/test/keyvault.test.ts
@@ -27,6 +27,8 @@ function mockNewlyCreatedKeyVaultSecretClients() {
     mockSecretClientGetSecret(mockedData.map(([_key, secretUri, value]) => [secretUri, value]));
 }
 describe("key vault reference", function () {
+    this.timeout(10000);
+
     beforeEach(() => {
         mockAppConfigurationClient();
         mockNewlyCreatedKeyVaultSecretClients();
@@ -37,7 +39,7 @@ describe("key vault reference", function () {
     });
 
     it("require key vault options to resolve reference", async () => {
-        expect(load(createMockedConnectionString())).eventually.rejected;
+        return expect(load(createMockedConnectionString())).eventually.rejectedWith("Configure keyVaultOptions to resolve Key Vault Reference(s).");
     });
 
     it("should resolve key vault reference with credential", async () => {
@@ -93,7 +95,7 @@ describe("key vault reference", function () {
                 ]
             }
         });
-        expect(loadKeyVaultPromise).eventually.rejected;
+        return expect(loadKeyVaultPromise).eventually.rejectedWith("No key vault credential or secret resolver callback configured, and no matching secret client could be found.");
     });
 
     it("should fallback to use default credential when corresponding secret client not provided", async () => {

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -31,6 +31,8 @@ const mockedKVs = [{
 }].map(createMockedKeyValue);
 
 describe("load", function () {
+    this.timeout(10000);
+
     before(() => {
         mockAppConfigurationClientListConfigurationSettings(mockedKVs);
     });
@@ -65,12 +67,12 @@ describe("load", function () {
     });
 
     it("should throw error given invalid connection string", async () => {
-        expect(load("invalid-connection-string")).eventually.rejected;
+        return expect(load("invalid-connection-string")).eventually.rejectedWith("Invalid connection string.");
     });
 
     it("should throw error given invalid endpoint URL", async () => {
         const credential = createMockedTokenCredential();
-        expect(load("invalid-endpoint-url", credential)).eventually.rejected;
+        return expect(load("invalid-endpoint-url", credential)).eventually.rejectedWith("Invalid endpoint URL.");
     });
 
     it("should trim key prefix if applicable", async () => {
@@ -117,7 +119,7 @@ describe("load", function () {
         expect(settings.get("KeyForEmptyValue")).eq("");
     });
 
-    it("should not support * or , in label filters", async () => {
+    it("should not support * in label filters", async () => {
         const connectionString = createMockedConnectionString();
         const loadWithWildcardLabelFilter = load(connectionString, {
             selectors: [{
@@ -125,15 +127,18 @@ describe("load", function () {
                 labelFilter: "*"
             }]
         });
-        expect(loadWithWildcardLabelFilter).to.eventually.rejected;
+        return expect(loadWithWildcardLabelFilter).to.eventually.rejectedWith("The characters '*' and ',' are not supported in label filters.");
+    });
 
+    it("should not support , in label filters", async () => {
+        const connectionString = createMockedConnectionString();
         const loadWithMultipleLabelFilter = load(connectionString, {
             selectors: [{
                 keyFilter: "app.*",
                 labelFilter: "labelA,labelB"
             }]
         });
-        expect(loadWithMultipleLabelFilter).to.eventually.rejected;
+        return expect(loadWithMultipleLabelFilter).to.eventually.rejectedWith("The characters '*' and ',' are not supported in label filters.");
     });
 
     it("should override config settings with same key but different label", async () => {


### PR DESCRIPTION
Ref:
[chai-promise](https://www.chaijs.com/plugins/chai-as-promised/) supports to also assert error message when a promise is rejected.
