### PR TITLE
Refactor AzureAppConfiguration with new interfaces

### DIFF
--- a/src/AzureAppConfiguration.ts
+++ b/src/AzureAppConfiguration.ts
@@ -32,18 +32,6 @@ export interface ConfigurationObjectConstructionOptions {
      * Default is '.'.
      */
     separator?: string;
-
-    /**
-     * The prefix of hierarchical keys to be converted object properties, usefull when converting a subset of the keys.
-     * Default is '', representing the root of the object.
-     */
-    prefix?: string;
-
-    /**
-     * The behavior when error or amibiguity occurs on converting hierarchical keys.
-     * Default is 'error'.
-     */
-    onError?: "error" | "ignore";
 }
 
 interface IGettable {

--- a/src/AzureAppConfiguration.ts
+++ b/src/AzureAppConfiguration.ts
@@ -16,17 +16,17 @@ export type AzureAppConfiguration = {
      * @param thisArg - Optional. Value to use as `this` when executing callback.
      */
     onRefresh(listener: () => any, thisArg?: any): Disposable;
-} & IGettable & IHierarchicalData;
+} & IGettable & IConfigurationObject;
 
-interface IHierarchicalData {
+interface IConfigurationObject {
     /**
-     * Convert the Map-styled data structure to hierarchical object properties.
+     * Construct configuration object based on Map-styled data structure and hierarchical keys.
      * @param options - The options to control the conversion behavior.
      */
-    toHierarchicalData(options?: HierarchicalDataConversionOptions): Record<string, any>;
+    constructConfigurationObject(options?: ConfigurationObjectConstructionOptions): Record<string, any>;
 }
 
-export interface HierarchicalDataConversionOptions {
+export interface ConfigurationObjectConstructionOptions {
     /**
      * The separator to use when converting hierarchical keys to object properties.
      * Default is '.'.

--- a/src/AzureAppConfiguration.ts
+++ b/src/AzureAppConfiguration.ts
@@ -29,10 +29,10 @@ interface IConfigurationObject {
 export interface ConfigurationObjectConstructionOptions {
     /**
      * The separator to use when converting hierarchical keys to object properties.
+     * Supported values: '.', ',', ';', '-', '_', '__', '/', ':'.
      * If separator is undefined, '.' will be used by default.
-
      */
-    separator?: string;
+    separator?: "." | "," | ";" | "-" | "_" | "__" | "/" | ":";
 }
 
 interface IGettable {

--- a/src/AzureAppConfiguration.ts
+++ b/src/AzureAppConfiguration.ts
@@ -16,12 +16,40 @@ export type AzureAppConfiguration = {
      * @param thisArg - Optional. Value to use as `this` when executing callback.
      */
     onRefresh(listener: () => any, thisArg?: any): Disposable;
-} & IGettable & AppConfigurationData;
+} & IGettable & IHierarchicalData;
 
-interface AppConfigurationData {
-    data: { [key: string]: any };
+interface IHierarchicalData {
+    /**
+     * Convert the Map-styled data structure to hierarchical object properties.
+     * @param options - The options to control the conversion behavior.
+     */
+    toHierarchicalData(options?: HierarchicalDataConversionOptions): Record<string, any>;
+}
+
+export interface HierarchicalDataConversionOptions {
+    /**
+     * The separator to use when converting hierarchical keys to object properties.
+     * Default is '.'.
+     */
+    separator?: string;
+
+    /**
+     * The prefix of hierarchical keys to be converted object properties, usefull when converting a subset of the keys.
+     * Default is '', representing the root of the object.
+     */
+    prefix?: string;
+
+    /**
+     * The behavior when error or amibiguity occurs on converting hierarchical keys.
+     * Default is 'error'.
+     */
+    onError?: "error" | "ignore";
 }
 
 interface IGettable {
+    /**
+     * Get the value of a key-value from the Map-styled data structure.
+     * @param key - The key of the key-value to be retrieved.
+     */
     get<T>(key: string): T | undefined;
 }

--- a/src/AzureAppConfiguration.ts
+++ b/src/AzureAppConfiguration.ts
@@ -16,4 +16,12 @@ export type AzureAppConfiguration = {
      * @param thisArg - Optional. Value to use as `this` when executing callback.
      */
     onRefresh(listener: () => any, thisArg?: any): Disposable;
-} & ReadonlyMap<string, any>;
+} & IGettable & AppConfigurationData;
+
+interface AppConfigurationData {
+    data: { [key: string]: any };
+}
+
+interface IGettable {
+    get<T>(key: string): T | undefined;
+}

--- a/src/AzureAppConfiguration.ts
+++ b/src/AzureAppConfiguration.ts
@@ -29,7 +29,8 @@ interface IConfigurationObject {
 export interface ConfigurationObjectConstructionOptions {
     /**
      * The separator to use when converting hierarchical keys to object properties.
-     * Default is '.'.
+     * If separator is undefined, '.' will be used by default.
+
      */
     separator?: string;
 }

--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -184,6 +184,10 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
      */
     constructConfigurationObject(options?: ConfigurationObjectConstructionOptions): Record<string, any> {
         const separator = options?.separator ?? ".";
+        const validSeparators = [".", ",", ";", "-", "_", "__", "/", ":"];
+        if (!validSeparators.includes(separator)) {
+            throw new Error(`Invalid separator '${separator}'. Supported values: ${validSeparators.map(s => `'${s}'`).join(", ")}.`);
+        }
 
         // construct hierarchical data object from map
         const data: Record<string, any> = {};

--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -203,12 +203,17 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
                 }
                 // The path has been occupied by a non-object value, causing ambiguity.
                 if (typeof current[segment] !== "object") {
-                    throw new Error(`The key '${segments.slice(0, i + 1).join(separator)}' is not a valid path.`);
+                    throw new Error(`Ambiguity occurs when constructing configuration object from key '${key}', value '${value}'. The path '${segments.slice(0, i + 1).join(separator)}' has been occupied.`);
                 }
                 current = current[segment];
             }
+
+            const lastSegment = segments[segments.length - 1];
+            if (current[lastSegment] !== undefined) {
+                throw new Error(`Ambiguity occurs when constructing configuration object from key '${key}', value '${value}'. The key should not be part of another key.`);
+            }
             // set value to the last segment
-            current[segments[segments.length - 1]] = value;
+            current[lastSegment] = value;
         }
         return data;
     }

--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -3,7 +3,7 @@
 
 import { AppConfigurationClient, ConfigurationSetting, ConfigurationSettingId, GetConfigurationSettingOptions, GetConfigurationSettingResponse, ListConfigurationSettingsOptions } from "@azure/app-configuration";
 import { RestError } from "@azure/core-rest-pipeline";
-import { AzureAppConfiguration, HierarchicalDataConversionOptions } from "./AzureAppConfiguration";
+import { AzureAppConfiguration, ConfigurationObjectConstructionOptions } from "./AzureAppConfiguration";
 import { AzureAppConfigurationOptions } from "./AzureAppConfigurationOptions";
 import { IKeyValueAdapter } from "./IKeyValueAdapter";
 import { JsonKeyValueAdapter } from "./JsonKeyValueAdapter";
@@ -182,7 +182,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
     /**
      * Construct hierarchical data object from map.
      */
-    toHierarchicalData(options?: HierarchicalDataConversionOptions): Record<string, any> {
+    constructConfigurationObject(options?: ConfigurationObjectConstructionOptions): Record<string, any> {
         const separator = options?.separator ?? ".";
         const prefix = options?.prefix ?? "";
         const onError = options?.onError ?? "error";

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -25,7 +25,7 @@ describe("json", function () {
         const connectionString = createMockedConnectionString();
         const settings = await load(connectionString);
         expect(settings).not.undefined;
-        const logging = settings.get("json.settings.logging");
+        const logging = settings.get<any>("json.settings.logging");
         expect(logging).not.undefined;
         expect(logging.Test).not.undefined;
         expect(logging.Test.Level).eq("Debug");
@@ -43,7 +43,7 @@ describe("json", function () {
             }
         });
         expect(settings).not.undefined;
-        const resolvedSecret = settings.get("TestKey");
+        const resolvedSecret = settings.get<any>("TestKey");
         expect(resolvedSecret).not.undefined;
         expect(resolvedSecret.uri).undefined;
         expect(typeof resolvedSecret).eq("string");
@@ -74,7 +74,7 @@ describe("json", function () {
         const settings = await load(connectionString);
         expect(settings).not.undefined;
         expect(typeof settings.get("json.settings.object")).eq("object", "is object");
-        expect(Object.keys(settings.get("json.settings.object")).length).eq(0, "is empty object");
+        expect(Object.keys(settings.get<any>("json.settings.object")).length).eq(0, "is empty object");
         expect(Array.isArray(settings.get("json.settings.array"))).eq(true, "is array");
         expect(settings.get("json.settings.number")).eq(8, "is number");
         expect(settings.get("json.settings.string")).eq("string", "is string");

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -15,6 +15,18 @@ const mockedKVs = [{
     key: "app.settings.fontSize",
     value: "40",
 }, {
+    key: "app/settings/fontColor",
+    value: "red",
+}, {
+    key: "app/settings/fontSize",
+    value: "40",
+}, {
+    key: "app%settings%fontColor",
+    value: "red",
+}, {
+    key: "app%settings%fontSize",
+    value: "40",
+}, {
     key: "TestKey",
     label: "Test",
     value: "TestValue",
@@ -50,7 +62,7 @@ const mockedKVs = [{
 }, {
     key: "app5.settings",
     value: "placeholder"
-},
+}
 ].map(createMockedKeyValue);
 
 describe("load", function () {
@@ -286,5 +298,37 @@ describe("load", function () {
         // Both { '0': 'node_modules', '1': 'dist' } and ['node_modules', 'dist'] are valid.
         expect(data.app4.excludedFolders[0]).eq("node_modules");
         expect(data.app4.excludedFolders[1]).eq("dist");
+    });
+
+    it("should construct configuration object with customized separator", async () => {
+        const connectionString = createMockedConnectionString();
+        const settings = await load(connectionString, {
+            selectors: [{
+                keyFilter: "app/settings/*"
+            }]
+        });
+        expect(settings).not.undefined;
+        const data = settings.constructConfigurationObject({ separator: "/" });
+        expect(data).not.undefined;
+        expect(data.app.settings.fontColor).eq("red");
+        expect(data.app.settings.fontSize).eq("40");
+    });
+
+    it("should throw error when construct configuration object with invalid separator", async () => {
+        const connectionString = createMockedConnectionString();
+        const settings = await load(connectionString, {
+            selectors: [{
+                keyFilter: "app%settings%*"
+            }]
+        });
+        expect(settings).not.undefined;
+
+        expect(() => {
+            // Below line will throw error because of type checking, i.e. Type '"%"' is not assignable to type '"/" | "." | "," | ";" | "-" | "_" | "__" | ":" | undefined'.ts(2322)
+            // Here force to turn if off for testing purpose, as JavaScript does not have type checking.
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            settings.constructConfigurationObject({ separator: "%" });
+        }).to.throw("Invalid separator '%'. Supported values: '.', ',', ';', '-', '_', '__', '/', ':'.");
     });
 });

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -44,7 +44,13 @@ const mockedKVs = [{
 }, {
     key: "app4.excludedFolders.1",
     value: "dist"
-}
+}, {
+    key: "app5.settings.fontColor",
+    value: "yellow"
+}, {
+    key: "app5.settings",
+    value: "placeholder"
+},
 ].map(createMockedKeyValue);
 
 describe("load", function () {
@@ -233,7 +239,7 @@ describe("load", function () {
      * get() will return "placeholder" for "app3.settings" and "yellow" for "app3.settings.fontColor", as expected.
      * data.app3.settings will return "placeholder" as a whole JSON object, which is not guarenteed to be correct.
      */
-    it("Edge case: Hierarchical key-value pairs with overlapped key prefix.", async () => {
+    it("Edge case 1: Hierarchical key-value pairs with overlapped key prefix.", async () => {
         const connectionString = createMockedConnectionString();
         const settings = await load(connectionString, {
             selectors: [{
@@ -243,7 +249,28 @@ describe("load", function () {
         expect(settings).not.undefined;
         expect(() => {
             settings.constructConfigurationObject();
-        }).to.throw("The key 'app3.settings' is not a valid path.");
+        }).to.throw("Ambiguity occurs when constructing configuration object from key 'app3.settings.fontColor', value 'yellow'. The path 'app3.settings' has been occupied.");
+    });
+
+    /**
+     * Edge case: Hierarchical key-value pairs with overlapped key prefix.
+     * key: "app5.settings.fontColor" => value: "yellow"
+     * key: "app5.settings" => value: "placeholder"
+     *
+     * When ocnstructConfigurationObject() is called, it first constructs from key "app5.settings.fontColor" and then from key "app5.settings".
+     * An error will be thrown when constructing from key "app5.settings" because there is ambiguity between the two keys.
+     */
+    it("Edge case 1: Hierarchical key-value pairs with overlapped key prefix.", async () => {
+        const connectionString = createMockedConnectionString();
+        const settings = await load(connectionString, {
+            selectors: [{
+                keyFilter: "app5.settings*"
+            }]
+        });
+        expect(settings).not.undefined;
+        expect(() => {
+            settings.constructConfigurationObject();
+        }).to.throw("Ambiguity occurs when constructing configuration object from key 'app5.settings', value 'placeholder'. The key should not be part of another key.");
     });
 
     it("should construct configuration object with array", async () => {

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -185,7 +185,7 @@ describe("load", function () {
             }]
         });
         expect(settings).not.undefined;
-        const data = settings.toHierarchicalData();
+        const data = settings.constructConfigurationObject();
         expect(data).not.undefined;
         expect(data.app.settings.fontColor).eq("red");
         expect(data.app.settings.fontSize).eq("40");
@@ -199,7 +199,7 @@ describe("load", function () {
             }]
         });
         expect(settings).not.undefined;
-        const data = settings.toHierarchicalData();
+        const data = settings.constructConfigurationObject();
         expect(data).not.undefined;
         expect(data.app2.settings.fontColor).eq("blue");
         expect(data.app2.settings.fontSize).eq(20);
@@ -238,7 +238,7 @@ describe("load", function () {
         expect(settings.get("app3.settings")).eq("placeholder");
         expect(settings.get("app3.settings.fontColor")).eq("yellow");
         // use data property
-        const data = settings.toHierarchicalData({ onError: "ignore" }); // ignore error on hierarchical key conversion
+        const data = settings.constructConfigurationObject({ onError: "ignore" }); // ignore error on hierarchical key conversion
         expect(data.app3.settings).not.eq("placeholder"); // not as expected.
         expect(data.app3.settings.fontColor).eq("yellow");
     });
@@ -252,7 +252,7 @@ describe("load", function () {
         });
         expect(settings).not.undefined;
         expect(() => {
-            settings.toHierarchicalData();
+            settings.constructConfigurationObject();
         }).to.throw("The key 'app3.settings' is not a valid path.");
     });
 });


### PR DESCRIPTION
#### Design
We support both two approaches to access key-values, maximize compatibility with customer's application code. For easier adoption of Azure App Configuration, and less code change.

```ts
AzureAppConfiguration {
  get<T>(key: string): T | undefined;  // preferred method, e.g. config.get("app.settings.color")
    constructConfigurationObject(options);    // helper function to construct hierarchical object, compatible with chained dot notation, e.g. config.app.settings.color
}
```

#### Edge case (for using configuration object only):
```
Hierarchical key-value pairs with overlapped key prefix:
  key: "app3.settings" => value: "placeholder"
  key: "app3.settings.fontColor" => value: "yellow"

How to re-construct data object from key-values?
config.app3.settings = ? 
```
In this case, constructConfigurationObject() throws an error.

#### Mitigation approach
~~Add an option `skipObjectValidataion: boolean`, default to `false`.~~
~~- `true`. Throw an error when constructing the `data` object., because of ambiguity.~~
~~- `false`. Skip the validation, allow information lost in `data` object, as the preferred `get()` method can always have the expected results.~~
(propose to use `constructConfigurationObject(options)` as below, which would not affect the original `load()` call)