### PR TITLE
Update example to explicitly enable refresh

### DIFF
--- a/examples/refresh.mjs
+++ b/examples/refresh.mjs
@@ -24,6 +24,7 @@ const settings = await load(connectionString, {
     }],
     trimKeyPrefixes: ["app.settings."],
     refreshOptions: {
+        enabled: true,
         watchedSettings: [{ key: "app.settings.sentinel" }],
         refreshIntervalInMs: 10 * 1000 // Default value is 30 seconds, shorted for this sample
     }


### PR DESCRIPTION
In latest design, RefreshOptions.enabled specifies whether the refresh is enabled, false by default. Otherwise it throws error "Refresh is not enabled" when calling settings.refresh().