### PR TITLE
Exclude feature flags from loaded settings

### DIFF
--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AppConfigurationClient, ConfigurationSetting, ConfigurationSettingId, GetConfigurationSettingOptions, GetConfigurationSettingResponse, ListConfigurationSettingsOptions } from "@azure/app-configuration";
+import { AppConfigurationClient, ConfigurationSetting, ConfigurationSettingId, GetConfigurationSettingOptions, GetConfigurationSettingResponse, ListConfigurationSettingsOptions, isFeatureFlag } from "@azure/app-configuration";
 import { RestError } from "@azure/core-rest-pipeline";
 import { AzureAppConfiguration, ConfigurationObjectConstructionOptions } from "./AzureAppConfiguration";
 import { AzureAppConfigurationOptions } from "./AzureAppConfigurationOptions";
@@ -150,7 +150,9 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
             const settings = this.#client.listConfigurationSettings(listOptions);
 
             for await (const setting of settings) {
-                loadedSettings.push(setting);
+                if (!isFeatureFlag(setting)) { // exclude feature flags
+                    loadedSettings.push(setting);
+                }
             }
         }
         return loadedSettings;

--- a/src/JsonKeyValueAdapter.ts
+++ b/src/JsonKeyValueAdapter.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ConfigurationSetting, secretReferenceContentType } from "@azure/app-configuration";
+import { ConfigurationSetting, featureFlagContentType, secretReferenceContentType } from "@azure/app-configuration";
 import { IKeyValueAdapter } from "./IKeyValueAdapter";
 
 export class JsonKeyValueAdapter implements IKeyValueAdapter {
     static readonly #ExcludedJsonContentTypes: string[] = [
-        secretReferenceContentType
-        // TODO: exclude application/vnd.microsoft.appconfig.ff+json after feature management is supported
+        secretReferenceContentType,
+        featureFlagContentType
     ];
 
     canProcess(setting: ConfigurationSetting): boolean {

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -62,6 +62,17 @@ const mockedKVs = [{
 }, {
     key: "app5.settings",
     value: "placeholder"
+}, {
+    key: ".appconfig.featureflag/Beta",
+    value: JSON.stringify({
+        "id": "Beta",
+        "description": "",
+        "enabled": true,
+        "conditions": {
+            "client_filters": []
+        }
+    }),
+    contentType: "application/vnd.microsoft.appconfig.ff+json;charset=utf-8"
 }
 ].map(createMockedKeyValue);
 
@@ -108,6 +119,13 @@ describe("load", function () {
     it("should throw error given invalid endpoint URL", async () => {
         const credential = createMockedTokenCredential();
         return expect(load("invalid-endpoint-url", credential)).eventually.rejectedWith("Invalid endpoint URL.");
+    });
+
+    it("should not include feature flags directly in the settings", async () => {
+        const connectionString = createMockedConnectionString();
+        const settings = await load(connectionString);
+        expect(settings).not.undefined;
+        expect(settings.get(".appconfig.featureflag/Beta")).undefined;
     });
 
     it("should filter by key and label, has(key) and get(key) should work", async () => {


### PR DESCRIPTION
#### Context information

According to Feature Management design, the loaded key-values should be:
- FM is enabled: feature flags are included as a whole, under "feature_management" key.
- FM is not enabled: feature flags are excluded. 

#### Current behavior

Feature flags will be loaded and treated as JSON objects if customer specifies proper selectors, e.g. `keyFilter: "
.appconfig.featureflag/*"`


#### Expected behavior

Before FM is supported, the default behavior should be consistent with FM is disabled. We should exclude feature flags. 
**This will avoid future breaking change.**