### PR TITLE
parse JSON string resolved from kvr

### DIFF
--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -86,7 +86,10 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
 
         // TODO: should add more adapters to process different type of values
         // feature flag, others
+
+        // Note: the order matters. Results from the first adapter will be passed to the next one.
         this.#adapters.push(new AzureKeyVaultKeyValueAdapter(options?.keyVaultOptions));
+        // Json adapter should be the last one.
         this.#adapters.push(new JsonKeyValueAdapter());
     }
 
@@ -325,7 +328,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
     async #processAdapters(setting: ConfigurationSetting<string>): Promise<[string, unknown]> {
         for (const adapter of this.#adapters) {
             if (adapter.canProcess(setting)) {
-                return adapter.processKeyValue(setting);
+                await adapter.processKeyValue(setting);
             }
         }
         return [setting.key, setting.value];

--- a/src/IKeyValueAdapter.ts
+++ b/src/IKeyValueAdapter.ts
@@ -5,12 +5,11 @@ import { ConfigurationSetting } from "@azure/app-configuration";
 export interface IKeyValueAdapter {
     /**
      * Determine whether the adapter applies to a configuration setting.
-     * Note: A setting is expected to be processed by at most one adapter.
      */
     canProcess(setting: ConfigurationSetting): boolean;
 
     /**
-     * This method process the original configuration setting, and returns processed key and value in an array.
+     * This method process the original configuration setting in place.
      */
-    processKeyValue(setting: ConfigurationSetting): Promise<[string, unknown]>;
+    processKeyValue(setting: ConfigurationSetting): Promise<void>;
 }

--- a/src/JsonKeyValueAdapter.ts
+++ b/src/JsonKeyValueAdapter.ts
@@ -20,7 +20,7 @@ export class JsonKeyValueAdapter implements IKeyValueAdapter {
         return isJsonContentType(setting.contentType);
     }
 
-    async processKeyValue(setting: ConfigurationSetting): Promise<[string, unknown]> {
+    async processKeyValue(setting: ConfigurationSetting): Promise<void> {
         let parsedValue: unknown;
         if (setting.value !== undefined) {
             try {
@@ -31,7 +31,7 @@ export class JsonKeyValueAdapter implements IKeyValueAdapter {
         } else {
             parsedValue = setting.value;
         }
-        return [setting.key, parsedValue];
+        (setting as ConfigurationSetting<any>).value = parsedValue;
     }
 }
 


### PR DESCRIPTION
fix #78 

Now if a JSON string is stored in Key Vault with content type "application/json", it will be loaded as parsed object instead of a raw string.