### PR TITLE
Use isRestError API

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -4,7 +4,7 @@ import dts from "rollup-plugin-dts";
 
 export default [
   {
-    external: ["@azure/app-configuration", "@azure/keyvault-secrets"],
+    external: ["@azure/app-configuration", "@azure/keyvault-secrets", "@azure/core-rest-pipeline"],
     input: "src/index.ts",
     output: [
       {

--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { AppConfigurationClient, ConfigurationSetting, ConfigurationSettingId, GetConfigurationSettingOptions, GetConfigurationSettingResponse, ListConfigurationSettingsOptions, featureFlagPrefix, isFeatureFlag } from "@azure/app-configuration";
-import { RestError } from "@azure/core-rest-pipeline";
+import { isRestError } from "@azure/core-rest-pipeline";
 import { AzureAppConfiguration, ConfigurationObjectConstructionOptions } from "./AzureAppConfiguration";
 import { AzureAppConfigurationOptions } from "./AzureAppConfigurationOptions";
 import { IKeyValueAdapter } from "./IKeyValueAdapter";
@@ -524,7 +524,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
                 customOptions
             );
         } catch (error) {
-            if (error instanceof RestError && error.statusCode === 404) {
+            if (isRestError(error) && error.statusCode === 404) {
                 response = undefined;
             } else {
                 throw error;


### PR DESCRIPTION
## Why this PR?

Use `isRestError` API provided by "@azure/core-rest-pipeline".

Add "@azure/core-rest-pipeline" to external dependency in rollup.config to resolve this warning while building the project:

![image](https://github.com/user-attachments/assets/184f0077-2779-43b3-bfbe-f1a57ba0cbce)
