### PR TITLE
Make testsuite compatible with node 22.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/test/requestTracing.test.ts
+++ b/test/requestTracing.test.ts
@@ -168,7 +168,7 @@ describe("request tracing", function () {
             // Restore the original values after each test
             // global.navigator was added in node 21, https://nodejs.org/api/globals.html#navigator_1
             // global.navigator only has a getter, so we have to use Object.defineProperty to modify it
-            Object.defineProperty(global, 'navigator', {
+            Object.defineProperty(global, "navigator", {
                 value: originalNavigator,
                 configurable: true
             });
@@ -179,7 +179,7 @@ describe("request tracing", function () {
 
         it("should identify WebWorker environment", async () => {
             (global as any).WorkerNavigator = function WorkerNavigator() { };
-            Object.defineProperty(global, 'navigator', {
+            Object.defineProperty(global, "navigator", {
                 value: new (global as any).WorkerNavigator(),
                 configurable: true
             });
@@ -196,7 +196,7 @@ describe("request tracing", function () {
         });
 
         it("is not WebWorker when WorkerNavigator is undefined", async () => {
-            Object.defineProperty(global, 'navigator', {
+            Object.defineProperty(global, "navigator", {
                 value: { userAgent: "node.js" } as any, // Mock navigator
                 configurable: true
             });
@@ -214,7 +214,7 @@ describe("request tracing", function () {
         });
 
         it("is not WebWorker when navigator is not an instance of WorkerNavigator", async () => {
-            Object.defineProperty(global, 'navigator', {
+            Object.defineProperty(global, "navigator", {
                 value: { userAgent: "node.js" } as any, // Mock navigator but not an instance of WorkerNavigator
                 configurable: true
             });
@@ -233,7 +233,7 @@ describe("request tracing", function () {
 
         it("is not WebWorker when WorkerGlobalScope is undefined", async () => {
             (global as any).WorkerNavigator = function WorkerNavigator() { };
-            Object.defineProperty(global, 'navigator', {
+            Object.defineProperty(global, "navigator", {
                 value: new (global as any).WorkerNavigator(),
                 configurable: true
             });
@@ -251,7 +251,7 @@ describe("request tracing", function () {
 
         it("is not WebWorker when importScripts is undefined", async () => {
             (global as any).WorkerNavigator = function WorkerNavigator() { };
-            Object.defineProperty(global, 'navigator', {
+            Object.defineProperty(global, "navigator", {
                 value: new (global as any).WorkerNavigator(),
                 configurable: true
             });

--- a/test/requestTracing.test.ts
+++ b/test/requestTracing.test.ts
@@ -166,7 +166,12 @@ describe("request tracing", function () {
 
         afterEach(() => {
             // Restore the original values after each test
-            (global as any).navigator = originalNavigator;
+            // global.navigator was added in node 21, https://nodejs.org/api/globals.html#navigator_1
+            // global.navigator only has a getter, so we have to use Object.defineProperty to modify it
+            Object.defineProperty(global, 'navigator', {
+                value: originalNavigator,
+                configurable: true
+            });
             (global as any).WorkerNavigator = originalWorkerNavigator;
             (global as any).WorkerGlobalScope = originalWorkerGlobalScope;
             (global as any).importScripts = originalImportScripts;
@@ -174,7 +179,10 @@ describe("request tracing", function () {
 
         it("should identify WebWorker environment", async () => {
             (global as any).WorkerNavigator = function WorkerNavigator() { };
-            (global as any).navigator = new (global as any).WorkerNavigator();
+            Object.defineProperty(global, 'navigator', {
+                value: new (global as any).WorkerNavigator(),
+                configurable: true
+            });
             (global as any).WorkerGlobalScope = function WorkerGlobalScope() { };
             (global as any).importScripts = function importScripts() { };
 
@@ -188,7 +196,10 @@ describe("request tracing", function () {
         });
 
         it("is not WebWorker when WorkerNavigator is undefined", async () => {
-            (global as any).navigator = { userAgent: "node.js" } as any; // Mock navigator
+            Object.defineProperty(global, 'navigator', {
+                value: { userAgent: "node.js" } as any, // Mock navigator
+                configurable: true
+            });
             (global as any).WorkerNavigator = undefined;
             (global as any).WorkerGlobalScope = function WorkerGlobalScope() { };
             (global as any).importScripts = function importScripts() { };
@@ -203,7 +214,10 @@ describe("request tracing", function () {
         });
 
         it("is not WebWorker when navigator is not an instance of WorkerNavigator", async () => {
-            (global as any).navigator = { userAgent: "node.js" } as any; // Mock navigator but not an instance of WorkerNavigator
+            Object.defineProperty(global, 'navigator', {
+                value: { userAgent: "node.js" } as any, // Mock navigator but not an instance of WorkerNavigator
+                configurable: true
+            });
             (global as any).WorkerNavigator = function WorkerNavigator() { };
             (global as any).WorkerGlobalScope = function WorkerGlobalScope() { };
             (global as any).importScripts = function importScripts() { };
@@ -219,7 +233,10 @@ describe("request tracing", function () {
 
         it("is not WebWorker when WorkerGlobalScope is undefined", async () => {
             (global as any).WorkerNavigator = function WorkerNavigator() { };
-            (global as any).navigator = new (global as any).WorkerNavigator();
+            Object.defineProperty(global, 'navigator', {
+                value: new (global as any).WorkerNavigator(),
+                configurable: true
+            });
             (global as any).WorkerGlobalScope = undefined;
             (global as any).importScripts = function importScripts() { };
 
@@ -234,7 +251,10 @@ describe("request tracing", function () {
 
         it("is not WebWorker when importScripts is undefined", async () => {
             (global as any).WorkerNavigator = function WorkerNavigator() { };
-            (global as any).navigator = new (global as any).WorkerNavigator();
+            Object.defineProperty(global, 'navigator', {
+                value: new (global as any).WorkerNavigator(),
+                configurable: true
+            });
             (global as any).WorkerGlobalScope = function WorkerGlobalScope() { };
             (global as any).importScripts = undefined;
 


### PR DESCRIPTION
## Why this PR?
#95 
Global [navigator](https://nodejs.org/api/globals.html#navigator_1) was introduced in node 21. It will cause our testsuite when running node 22. 

According to the node.js [roadmap](https://nodejs.org/en/about/previous-releases), v22 will be active soon. This PR adds v22 to the CI pipeline.