### PR TITLE
Feature Flag Telemetry Support

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -4,7 +4,7 @@ import dts from "rollup-plugin-dts";
 
 export default [
   {
-    external: ["@azure/app-configuration", "@azure/keyvault-secrets", "@azure/core-rest-pipeline"],
+    external: ["@azure/app-configuration", "@azure/keyvault-secrets", "@azure/core-rest-pipeline", "crypto"],
     input: "src/index.ts",
     output: [
       {

--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -258,8 +258,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
     }
 
     async #loadFeatureFlags() {
-        // Temporary map to store feature flags, key is the key of the setting, value is the raw value of the setting
-        const featureFlagsMap = new Map<string, any>();
+        const featureFlagSettings: ConfigurationSetting[] = [];
         for (const selector of this.#featureFlagSelectors) {
             const listOptions: ListConfigurationSettingsOptions = {
                 keyFilter: `${featureFlagPrefix}${selector.keyFilter}`,
@@ -276,7 +275,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
                 pageEtags.push(page.etag ?? "");
                 for (const setting of page.items) {
                     if (isFeatureFlag(setting)) {
-                        featureFlagsMap.set(setting.key, setting);
+                        featureFlagSettings.push(setting);
                     }
                 }
             }
@@ -285,7 +284,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
 
         // parse feature flags
         const featureFlags = await Promise.all(
-            Array.from(featureFlagsMap.values()).map(setting => this.#parseFeatureFlag(setting))
+            featureFlagSettings.map(setting => this.#parseFeatureFlag(setting))
         );
 
         // feature_management is a reserved key, and feature_flags is an array of feature flags

--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -538,7 +538,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
         return response;
     }
 
-    async #parseFeatureFlag(setting: ConfigurationSetting<string>): Promise<any>{
+    async #parseFeatureFlag(setting: ConfigurationSetting<string>): Promise<any> {
         const rawFlag = setting.value;
         if (rawFlag === undefined) {
             throw new Error("The value of configuration setting cannot be undefined.");
@@ -597,13 +597,13 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
             const hashBuffer = await crypto.subtle.digest("SHA-256", data);
             const hashArray = new Uint8Array(hashBuffer);
             const base64String = btoa(String.fromCharCode(...hashArray));
-            const base64urlString = base64String.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-            return base64urlString
+            const base64urlString = base64String.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+            return base64urlString;
         }
         // In Node.js, use the crypto module's hash function
         else {
             const hash = crypto.createHash("sha256").update(data).digest();
-            return hash.toString("base64url")
+            return hash.toString("base64url");
         }
     }
 

--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -595,7 +595,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
         if (crypto.subtle) {
             const hashBuffer = await crypto.subtle.digest("SHA-256", data);
             const hashArray = new Uint8Array(hashBuffer);
-            const base64String = window.btoa(String.fromCharCode(...hashArray));
+            const base64String = btoa(String.fromCharCode(...hashArray));
             const base64urlString = base64String.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
             return base64urlString;
         }

--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -595,7 +595,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
         if (crypto.subtle) {
             const hashBuffer = await crypto.subtle.digest("SHA-256", data);
             const hashArray = new Uint8Array(hashBuffer);
-            const base64String = btoa(String.fromCharCode(...hashArray));
+            const base64String = window.btoa(String.fromCharCode(...hashArray));
             const base64urlString = base64String.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
             return base64urlString;
         }

--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -9,7 +9,7 @@ import { IKeyValueAdapter } from "./IKeyValueAdapter";
 import { JsonKeyValueAdapter } from "./JsonKeyValueAdapter";
 import { DEFAULT_REFRESH_INTERVAL_IN_MS, MIN_REFRESH_INTERVAL_IN_MS } from "./RefreshOptions";
 import { Disposable } from "./common/disposable";
-import { FEATURE_FLAGS_KEY_NAME, FEATURE_MANAGEMENT_KEY_NAME, TELEMETRY_KEY_NAME, METADATA_KEY_NAME, ETAG_KEY_NAME, FEATURE_FLAG_ID_KEY_NAME, FEATURE_FLAG_REFERENCE_KEY_NAME } from "./featureManagement/constants";
+import { FEATURE_FLAGS_KEY_NAME, FEATURE_MANAGEMENT_KEY_NAME, TELEMETRY_KEY_NAME, ENABLED_KEY_NAME, METADATA_KEY_NAME, ETAG_KEY_NAME, FEATURE_FLAG_ID_KEY_NAME, FEATURE_FLAG_REFERENCE_KEY_NAME } from "./featureManagement/constants";
 import { AzureKeyVaultKeyValueAdapter } from "./keyvault/AzureKeyVaultKeyValueAdapter";
 import { RefreshTimer } from "./refresh/RefreshTimer";
 import { getConfigurationSettingWithTrace, listConfigurationSettingsWithTrace, requestTracingEnabled } from "./requestTracing/utils";
@@ -545,7 +545,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
         }
         const featureFlag = JSON.parse(rawFlag);
 
-        if (featureFlag[TELEMETRY_KEY_NAME]) {
+        if (featureFlag[TELEMETRY_KEY_NAME] && featureFlag[TELEMETRY_KEY_NAME][ENABLED_KEY_NAME] === true) {
             const metadata = featureFlag[TELEMETRY_KEY_NAME][METADATA_KEY_NAME];
             featureFlag[TELEMETRY_KEY_NAME][METADATA_KEY_NAME] = {
                 [ETAG_KEY_NAME]: setting.etag,

--- a/src/featureManagement/constants.ts
+++ b/src/featureManagement/constants.ts
@@ -4,6 +4,7 @@
 export const FEATURE_MANAGEMENT_KEY_NAME = "feature_management";
 export const FEATURE_FLAGS_KEY_NAME = "feature_flags";
 export const TELEMETRY_KEY_NAME = "telemetry";
+export const ENABLED_KEY_NAME = "enabled";
 export const METADATA_KEY_NAME = "metadata";
 export const ETAG_KEY_NAME = "Etag";
 export const FEATURE_FLAG_ID_KEY_NAME = "FeatureFlagId";

--- a/src/featureManagement/constants.ts
+++ b/src/featureManagement/constants.ts
@@ -3,8 +3,8 @@
 
 export const FEATURE_MANAGEMENT_KEY_NAME = "feature_management";
 export const FEATURE_FLAGS_KEY_NAME = "feature_flags";
-export const TELEMETRY_KEY_NAME = "telemetry"
-export const METADATA_KEY_NAME = "metadata"
-export const ETAG_KEY_NAME = "Etag"
-export const FEATURE_FLAG_ID_KEY_NAME = "FeatureFlagId"
-export const FEATURE_FLAG_REFERENCE_KEY_NAME = "FeatureFlagReference"
+export const TELEMETRY_KEY_NAME = "telemetry";
+export const METADATA_KEY_NAME = "metadata";
+export const ETAG_KEY_NAME = "Etag";
+export const FEATURE_FLAG_ID_KEY_NAME = "FeatureFlagId";
+export const FEATURE_FLAG_REFERENCE_KEY_NAME = "FeatureFlagReference";

--- a/src/featureManagement/constants.ts
+++ b/src/featureManagement/constants.ts
@@ -3,3 +3,8 @@
 
 export const FEATURE_MANAGEMENT_KEY_NAME = "feature_management";
 export const FEATURE_FLAGS_KEY_NAME = "feature_flags";
+export const TELEMETRY_KEY_NAME = "telemetry"
+export const METADATA_KEY_NAME = "metadata"
+export const ETAG_KEY_NAME = "Etag"
+export const FEATURE_FLAG_ID_KEY_NAME = "FeatureFlagId"
+export const FEATURE_FLAG_REFERENCE_KEY_NAME = "FeatureFlagReference"

--- a/src/load.ts
+++ b/src/load.ts
@@ -32,6 +32,7 @@ export async function load(
 ): Promise<AzureAppConfiguration> {
     const startTimestamp = Date.now();
     let client: AppConfigurationClient;
+    let clientEndpoint: string | undefined;
     let options: AzureAppConfigurationOptions | undefined;
 
     // input validation
@@ -40,12 +41,13 @@ export async function load(
         options = credentialOrOptions as AzureAppConfigurationOptions;
         const clientOptions = getClientOptions(options);
         client = new AppConfigurationClient(connectionString, clientOptions);
+        clientEndpoint = parseEndpoint(connectionStringOrEndpoint);
     } else if ((connectionStringOrEndpoint instanceof URL || typeof connectionStringOrEndpoint === "string") && instanceOfTokenCredential(credentialOrOptions)) {
-        let endpoint = connectionStringOrEndpoint;
         // ensure string is a valid URL.
-        if (typeof endpoint === "string") {
+        if (typeof connectionStringOrEndpoint === "string") {
             try {
-                endpoint = new URL(endpoint);
+                let endpoint = new URL(connectionStringOrEndpoint);
+                clientEndpoint = endpoint.toString();
             } catch (error) {
                 if (error.code === "ERR_INVALID_URL") {
                     throw new Error("Invalid endpoint URL.", { cause: error });
@@ -53,17 +55,19 @@ export async function load(
                     throw error;
                 }
             }
+        } else {
+            clientEndpoint = connectionStringOrEndpoint.toString();
         }
         const credential = credentialOrOptions as TokenCredential;
         options = appConfigOptions;
         const clientOptions = getClientOptions(options);
-        client = new AppConfigurationClient(endpoint.toString(), credential, clientOptions);
+        client = new AppConfigurationClient(clientEndpoint, credential, clientOptions);
     } else {
         throw new Error("A connection string or an endpoint with credential must be specified to create a client.");
     }
 
     try {
-        const appConfiguration = new AzureAppConfigurationImpl(client, options);
+        const appConfiguration = new AzureAppConfigurationImpl(client, clientEndpoint, options);
         await appConfiguration.load();
         return appConfiguration;
     } catch (error) {
@@ -103,4 +107,19 @@ function getClientOptions(options?: AzureAppConfigurationOptions): AppConfigurat
             userAgentPrefix
         }
     });
+}
+
+function parseEndpoint(connectionString: string): string | undefined {
+    const parts = connectionString.split(";");
+    const endpointPart = parts.find(part => part.startsWith("Endpoint="));
+    
+    if (endpointPart) {
+        let endpoint = endpointPart.split("=")[1];
+        if (!endpoint.endsWith("/")) {
+            endpoint += "/";
+        }
+        return endpoint;
+    }
+
+    return undefined;
 }

--- a/src/load.ts
+++ b/src/load.ts
@@ -46,8 +46,8 @@ export async function load(
         // ensure string is a valid URL.
         if (typeof connectionStringOrEndpoint === "string") {
             try {
-                let endpoint = new URL(connectionStringOrEndpoint);
-                clientEndpoint = endpoint.toString();
+                const endpointUrl = new URL(connectionStringOrEndpoint);
+                clientEndpoint = endpointUrl.toString();
             } catch (error) {
                 if (error.code === "ERR_INVALID_URL") {
                     throw new Error("Invalid endpoint URL.", { cause: error });
@@ -112,7 +112,7 @@ function getClientOptions(options?: AzureAppConfigurationOptions): AppConfigurat
 function parseEndpoint(connectionString: string): string | undefined {
     const parts = connectionString.split(";");
     const endpointPart = parts.find(part => part.startsWith("Endpoint="));
-    
+
     if (endpointPart) {
         let endpoint = endpointPart.split("=")[1];
         if (!endpoint.endsWith("/")) {

--- a/src/load.ts
+++ b/src/load.ts
@@ -41,7 +41,7 @@ export async function load(
         options = credentialOrOptions as AzureAppConfigurationOptions;
         const clientOptions = getClientOptions(options);
         client = new AppConfigurationClient(connectionString, clientOptions);
-        clientEndpoint = parseEndpoint(connectionStringOrEndpoint);
+        clientEndpoint = getEndpoint(connectionStringOrEndpoint);
     } else if ((connectionStringOrEndpoint instanceof URL || typeof connectionStringOrEndpoint === "string") && instanceOfTokenCredential(credentialOrOptions)) {
         // ensure string is a valid URL.
         if (typeof connectionStringOrEndpoint === "string") {
@@ -109,7 +109,7 @@ function getClientOptions(options?: AzureAppConfigurationOptions): AppConfigurat
     });
 }
 
-function parseEndpoint(connectionString: string): string | undefined {
+function getEndpoint(connectionString: string): string | undefined {
     const parts = connectionString.split(";");
     const endpointPart = parts.find(part => part.startsWith("Endpoint="));
 

--- a/test/featureFlag.test.ts
+++ b/test/featureFlag.test.ts
@@ -162,7 +162,7 @@ describe("feature flags", function () {
 
     it("should populate telemetry metadata", async () => {
         const connectionString = createMockedConnectionString();
-        let settings = await load(connectionString, {
+        const settings = await load(connectionString, {
             featureFlagOptions: {
                 enabled: true,
                 selectors: [
@@ -190,7 +190,7 @@ describe("feature flags", function () {
         expect(featureFlag.telemetry.metadata.Etag).equals("Etag");
         expect(featureFlag.telemetry.metadata.FeatureFlagId).equals("krkOsu9dVV9huwbQDPR6gkV_2T0buWxOCS-nNsj5-6g");
         expect(featureFlag.telemetry.metadata.FeatureFlagReference).equals(`${createMockedEndpoint()}/kv/.appconfig.featureflag/Telemetry_1`);
-    
+
         featureFlag = featureFlags[1];
         expect(featureFlag).not.undefined;
         expect(featureFlag.id).equals("Telemetry_2");


### PR DESCRIPTION
## Why this PR?

Populate feature flag id/feature flag reference/etag in feature flag's telemetry.metadata to facilitate Split experimentation.

Follows [PR](https://github.com/Azure/azure-sdk-for-python/pull/35254) and [PR](https://github.com/Azure/AppConfiguration-DotnetProvider/pull/517)