### PR TITLE
Adds Additional Undefined Check

### DIFF
--- a/src/requestTracing/utils.ts
+++ b/src/requestTracing/utils.ts
@@ -111,7 +111,7 @@ export function requestTracingEnabled(): boolean {
 
 function getEnvironmentVariable(name: string) {
     // Make it compatible with non-Node.js runtime
-    if (typeof process?.env === "object") {
+    if (typeof process !== "undefined" && typeof process?.env === "object") {
         return process.env[name];
     } else {
         return undefined;


### PR DESCRIPTION
`typeof` works great to see if a variable was declared. However the `?` operator does not work when the variable was not declared.

For example:

```
> bad?.foo
Uncaught ReferenceError: bad is not defined
> bad = undefined
undefined
> bad?.foo
undefined
```

vs

```
> typeof bad
'undefined'
> bad = undefined
undefined
> typeof bad
'undefined'
```