### PR TITLE
Add dns module to rollup whitelist

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -4,7 +4,7 @@ import dts from "rollup-plugin-dts";
 
 export default [
   {
-    external: ["@azure/app-configuration", "@azure/keyvault-secrets", "@azure/core-rest-pipeline", "crypto"],
+    external: ["@azure/app-configuration", "@azure/keyvault-secrets", "@azure/core-rest-pipeline", "crypto", "dns/promises"],
     input: "src/index.ts",
     output: [
       {


### PR DESCRIPTION
Supress this warning when building the project. The `dns` module was introduced by #98 .
![image](https://github.com/user-attachments/assets/2172fb19-4dd4-47a7-8191-852c055559b0)
