### PR TITLE
Add feature management package version tracing

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -4,7 +4,7 @@ import dts from "rollup-plugin-dts";
 
 export default [
   {
-    external: ["@azure/app-configuration", "@azure/keyvault-secrets", "@azure/core-rest-pipeline", "crypto", "dns/promises"],
+    external: ["@azure/app-configuration", "@azure/keyvault-secrets", "@azure/core-rest-pipeline", "crypto", "dns/promises", "@microsoft/feature-management"],
     input: "src/index.ts",
     output: [
       {

--- a/src/ConfigurationClientManager.ts
+++ b/src/ConfigurationClientManager.ts
@@ -85,6 +85,9 @@ export class ConfigurationClientManager {
             this.#isFailoverable = false;
             return;
         }
+        if (this.#dns) {
+            return;
+        }
 
         try {
             this.#dns = await import("dns/promises");

--- a/src/requestTracing/constants.ts
+++ b/src/requestTracing/constants.ts
@@ -55,7 +55,7 @@ export const FAILOVER_REQUEST_TAG = "Failover";
 export const FEATURES_KEY = "Features";
 export const LOAD_BALANCE_CONFIGURED_TAG = "LB";
 
-// Feature management package version
+// Feature management package
 export const FM_PACKAGE_NAME = "@microsoft/feature-management";
 export const FM_VERSION_KEY = "FMJsVer";
 

--- a/src/requestTracing/constants.ts
+++ b/src/requestTracing/constants.ts
@@ -55,6 +55,10 @@ export const FAILOVER_REQUEST_TAG = "Failover";
 export const FEATURES_KEY = "Features";
 export const LOAD_BALANCE_CONFIGURED_TAG = "LB";
 
+// Feature management package version
+export const FM_PACKAGE_NAME = "@microsoft/feature-management";
+export const FM_VERSION_KEY = "FMJsVer";
+
 // Feature flag usage tracing
 export const FEATURE_FILTER_TYPE_KEY = "Filter";
 export const CUSTOM_FILTER_KEY = "CSTM";

--- a/src/requestTracing/utils.ts
+++ b/src/requestTracing/utils.ts
@@ -27,7 +27,8 @@ import {
     REPLICA_COUNT_KEY,
     FAILOVER_REQUEST_TAG,
     FEATURES_KEY,
-    LOAD_BALANCE_CONFIGURED_TAG
+    LOAD_BALANCE_CONFIGURED_TAG,
+    FM_VERSION_KEY
 } from "./constants";
 
 export interface RequestTracingOptions {
@@ -37,6 +38,7 @@ export interface RequestTracingOptions {
     replicaCount: number;
     isFailoverRequest: boolean;
     featureFlagTracing: FeatureFlagTracingOptions | undefined;
+    fmVersion: string | undefined;
 }
 
 // Utils
@@ -118,6 +120,9 @@ export function createCorrelationContextHeader(requestTracingOptions: RequestTra
     }
     if (requestTracingOptions.replicaCount > 0) {
         keyValues.set(REPLICA_COUNT_KEY, requestTracingOptions.replicaCount.toString());
+    }
+    if (requestTracingOptions.fmVersion) {
+        keyValues.set(FM_VERSION_KEY, requestTracingOptions.fmVersion);
     }
 
     // Compact tags: Features=LB+...


### PR DESCRIPTION
## Why this PR?

Collect JS FM package version usage in request tracing

Note that there is an exported constant [`VERSION`](https://github.com/microsoft/FeatureManagement-JavaScript/blob/main/src/feature-management/src/index.ts#L8) in JS FM package. This is by design to be a hook for us to know the package version.