### PR TITLE
Silently fail when srv query fail

### DIFF
--- a/src/ConfigurationClientManager.ts
+++ b/src/ConfigurationClientManager.ts
@@ -118,8 +118,7 @@ export class ConfigurationClientManager {
             (!this.#dynamicClients ||
             // All dynamic clients are in backoff means no client is available
             this.#dynamicClients.every(client => currentTime < client.backoffEndTime) ||
-            currentTime >= this.#lastFallbackClientRefreshTime + FALLBACK_CLIENT_REFRESH_EXPIRE_INTERVAL)
-        ) {
+            currentTime >= this.#lastFallbackClientRefreshTime + FALLBACK_CLIENT_REFRESH_EXPIRE_INTERVAL)) {
             this.#lastFallbackClientRefreshAttempt = currentTime;
             await this.#discoverFallbackClients(this.endpoint.hostname);
             return availableClients.concat(this.#dynamicClients);

--- a/src/ConfigurationClientManager.ts
+++ b/src/ConfigurationClientManager.ts
@@ -87,10 +87,11 @@ export class ConfigurationClientManager {
             this.#isFailoverable = false;
             return;
         }
-        if (this.#dns) {
+        if (this.#dns) { // dns module is already loaded
             return;
         }
 
+        // We can only know whether dns module is available during runtime.
         try {
             this.#dns = await import("dns/promises");
         } catch (error) {

--- a/src/ConfigurationClientManager.ts
+++ b/src/ConfigurationClientManager.ts
@@ -8,7 +8,6 @@ import { AzureAppConfigurationOptions, MaxRetries, MaxRetryDelayInMs } from "./A
 import { isBrowser, isWebWorker } from "./requestTracing/utils.js";
 import * as RequestTracing from "./requestTracing/constants.js";
 import { shuffleList } from "./common/utils.js";
-import { Resolver   } from "dns/promises";
 
 const TCP_ORIGIN_KEY_NAME = "_origin._tcp";
 const ALT_KEY_NAME = "_alt";
@@ -181,7 +180,7 @@ export class ConfigurationClientManager {
 
         try {
             // https://nodejs.org/api/dns.html#dnspromisesresolvesrvhostname
-            const resolver = new Resolver({timeout: DNS_RESOLVER_TIMEOUT, tries: DNS_RESOLVER_TRIES});
+            const resolver = new this.#dns.Resolver({timeout: DNS_RESOLVER_TIMEOUT, tries: DNS_RESOLVER_TRIES});
             // On success, resolveSrv() returns an array of SrvRecord
             // On failure, resolveSrv() throws an error with code 'ENOTFOUND'.
             const originRecords = await resolver.resolveSrv(`${TCP_ORIGIN_KEY_NAME}.${host}`); // look up SRV records for the origin host

--- a/src/ConfigurationClientManager.ts
+++ b/src/ConfigurationClientManager.ts
@@ -148,7 +148,7 @@ export class ConfigurationClientManager {
         try {
             result = await this.#querySrvTargetHost(host);
         } catch (error) {
-            console.warn(`Failed to build fallback clients, ${error.message}`);
+            console.warn(`Failed to build fallback clients. ${error.message}`);
             return; // swallow the error when srv query fails
         }
 

--- a/src/ConfigurationClientManager.ts
+++ b/src/ConfigurationClientManager.ts
@@ -155,9 +155,7 @@ export class ConfigurationClientManager {
             // We need to make sure the scale of the potential memory leak is controllable.
             const srvQueryPromise = this.#querySrvTargetHost(host);
             // There is no way to check the promise status synchronously, so we need to set the flag through the callback.
-            srvQueryPromise
-                .then(() => this.#srvQueryPending = false) // resolved
-                .catch(() => this.#srvQueryPending = false); // rejected
+            srvQueryPromise.finally(() => this.#srvQueryPending = false)
             // If the srvQueryPromise is rejected before timeout, the error will be caught in the catch block.
             // Otherwise, the timeout error will be caught in the catch block and the srvQueryPromise rejection will be ignored.
             result = await Promise.race([

--- a/src/ConfigurationClientManager.ts
+++ b/src/ConfigurationClientManager.ts
@@ -152,7 +152,7 @@ export class ConfigurationClientManager {
             console.warn(`Failed to build fallback clients, ${error.message}`);
             this.#lastFallbackClientRefreshTime = Date.now();
             return; // swallow the error when srv query fails
-        } 
+        }
 
         const srvTargetHosts = shuffleList(result);
         const newDynamicClients: ConfigurationClientWrapper[] = [];


### PR DESCRIPTION
## Why this PR?

- Fix the potential memory leak issue introduced by `Promise.race`.

- If srv query failed or timed out, it should not fail the whole provider, instead, it should be a silent error.