### PR TITLE
Fix startup retry bug

### DIFF
--- a/src/AzureAppConfigurationImpl.ts
+++ b/src/AzureAppConfigurationImpl.ts
@@ -395,6 +395,9 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
                     if (isInputError(error)) {
                         throw error;
                     }
+                    if (isRestError(error) && !isFailoverableError(error)) {
+                        throw error;
+                    }
                     if (abortSignal.aborted) {
                         return;
                     }


### PR DESCRIPTION
During the startup, if RestError occurs and it is not failoverable (e.g. 400 Invalid request parameter), the startup retry should break.

When using tag filters, the maximum allowed tag filter number is 5. A testcase is added in #188. 