### PR TITLE
Secret refresh bug fix

### DIFF
--- a/src/appConfigurationImpl.ts
+++ b/src/appConfigurationImpl.ts
@@ -482,7 +482,9 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
     async #loadConfigurationSettings(loadFeatureFlag: boolean = false): Promise<ConfigurationSetting[]> {
         const selectors = loadFeatureFlag ? this.#ffSelectors : this.#kvSelectors;
         const funcToExecute = async (client) => {
-            const loadedSettings: ConfigurationSetting[] = [];
+            // Use a Map to deduplicate configuration settings by key. When multiple selectors return settings with the same key,
+            // the configuration setting loaded by the later selector in the iteration order will override the one from the earlier selector.
+            const loadedSettings: Map<string, ConfigurationSetting> = new Map<string, ConfigurationSetting>();
             // deep copy selectors to avoid modification if current client fails
             const selectorsToUpdate = JSON.parse(
                 JSON.stringify(selectors)
@@ -506,7 +508,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
                         pageEtags.push(page.etag ?? "");
                         for (const setting of page.items) {
                             if (loadFeatureFlag === isFeatureFlag(setting)) {
-                                loadedSettings.push(setting);
+                                loadedSettings.set(setting.key, setting);
                             }
                         }
                     }
@@ -528,7 +530,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
                     for await (const page of pageIterator) {
                         for (const setting of page.items) {
                             if (loadFeatureFlag === isFeatureFlag(setting)) {
-                                loadedSettings.push(setting);
+                                loadedSettings.set(setting.key, setting);
                             }
                         }
                     }
@@ -540,7 +542,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
             } else {
                 this.#kvSelectors = selectorsToUpdate;
             }
-            return loadedSettings;
+            return Array.from(loadedSettings.values());
         };
 
         return await this.#executeWithFailoverPolicy(funcToExecute) as ConfigurationSetting[];


### PR DESCRIPTION
This bug is found due to the discussion [here](https://github.com/Azure/azure-sdk-for-python/pull/41882#discussion_r2307928772).

Corner case:

If there are a secret reference and a normal configuration setting with the same key (but different labels), the expected behavior is that if the normal configuration setting is loaded later, it should override the secret value. However, the current implementation will let the secret value to override it when secret refresh is enabled.

The fix is to dedupe the configuration settings with the same key in advance (before processing all configuration settings). In this case, if a secret reference is overrided by a normal key value it will not be stored in cache for the following secret refresh operation.