### PR TITLE
Bug fix: Provider should continue to refresh when previous refresh operation didn't complete

### DIFF
--- a/src/appConfigurationImpl.ts
+++ b/src/appConfigurationImpl.ts
@@ -590,21 +590,19 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
      * Updates etag of watched settings from loaded data. If a watched setting is not covered by any selector, a request will be sent to retrieve it.
      */
     async #updateWatchedKeyValuesEtag(existingSettings: ConfigurationSetting[]): Promise<void> {
+        const updatedSentinels: ConfigurationSettingId[] = [];
         for (const sentinel of this.#sentinels) {
             const matchedSetting = existingSettings.find(s => s.key === sentinel.key && s.label === sentinel.label);
             if (matchedSetting) {
-                sentinel.etag = matchedSetting.etag;
+                updatedSentinels.push( {...sentinel, etag: matchedSetting.etag} );
             } else {
                 // Send a request to retrieve key-value since it may be either not loaded or loaded with a different label or different casing
                 const { key, label } = sentinel;
                 const response = await this.#getConfigurationSetting({ key, label });
-                if (response) {
-                    sentinel.etag = response.etag;
-                } else {
-                    sentinel.etag = undefined;
-                }
+                updatedSentinels.push( {...sentinel, etag: response?.etag} );
             }
         }
+        this.#sentinels = updatedSentinels;
     }
 
     /**
@@ -662,7 +660,6 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
             if (response?.statusCode === 200 // created or changed
                 || (response === undefined && sentinel.etag !== undefined) // deleted
             ) {
-                sentinel.etag = response?.etag;// update etag of the sentinel
                 needRefresh = true;
                 break;
             }


### PR DESCRIPTION
## Bug fix

Sentinel key refresh scenario:

1. When `refresh()` is called, provider will first send a watch request to check whether sentinel key(i.e. watched setting) is changed
2. If sentinel key is changed, it will trigger a refresh-all, the provider will reload all configuration settings

The previous bug is that if the last refresh operation failed in step 2, the following refresh call will not continue to reload keyvalues until sentinel key is changed again.