### PR TITLE
Export AzureAppConfigurationOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 export { AzureAppConfiguration } from "./appConfiguration.js";
+export { AzureAppConfigurationOptions } from "./appConfigurationOptions.js";
 export { Disposable } from "./common/disposable.js";
+export { FeatureFlagOptions } from "./featureManagement/featureFlagOptions.js";
+export { KeyVaultOptions } from "./keyvault/keyVaultOptions.js";
 export { load } from "./load.js";
-export { KeyFilter, LabelFilter } from "./types.js";
+export { RefreshOptions, FeatureFlagRefreshOptions } from "./refresh/refreshOptions.js";
+export { StartupOptions } from "./startupOptions.js";
+export { KeyFilter, LabelFilter, SettingSelector } from "./types.js";
 export { VERSION } from "./version.js";


### PR DESCRIPTION
export `AzureAppConfigurationOptions` and the related option types to improve the developer experience.

```javascript
import { load, AzureAppConfigurationOptions } from "@azure/app-configuration-provider";

const options: AzureAppConfigurationOptions = {
    selectors: [{ keyFilter: "app.*" }],
    trimKeyPrefixes: ["app."]
};

const settings = await load(connectionString, options);
```