### PR TITLE
Revert "Bump uuid from 11.1.0 to 14.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "sinon": "^21.0.0",
         "tslib": "^2.8.1",
         "typescript": "^5.9.2",
-        "uuid": "^14.0.0",
+        "uuid": "^11.1.0",
         "vitest": "^3.2.4"
       }
     },
@@ -5365,9 +5365,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -5375,7 +5375,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist-node/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "sinon": "^21.0.0",
     "tslib": "^2.8.1",
     "typescript": "^5.9.2",
-    "uuid": "^14.0.0",
+    "uuid": "^11.1.0",
     "vitest": "^3.2.4",
     "@vitest/browser": "^3.2.4",
     "playwright": "^1.55.0"


### PR DESCRIPTION
Reverts Azure/AppConfiguration-JavaScriptProvider#312

uuid@14 dropped CommonJs support and ships ESM only, which will fail our common js test cases.