### PR TITLE
Fix feature flag refresh detection when page status is string

### DIFF
--- a/src/appConfigurationImpl.ts
+++ b/src/appConfigurationImpl.ts
@@ -750,7 +750,7 @@ export class AzureAppConfigurationImpl implements AzureAppConfiguration {
 
                 for await (const page of pageIterator) {
                     // when conditional request is sent, the response will be 304 if not changed
-                    if (page._response.status === 200) { // created or changed
+                    if (Number(page._response.status) === 200) { // created or changed
                         return true;
                     }
                 }

--- a/test/refresh.test.ts
+++ b/test/refresh.test.ts
@@ -7,7 +7,7 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 import { load } from "../src/index.js";
-import { mockAppConfigurationClientListConfigurationSettings, mockAppConfigurationClientGetConfigurationSetting, restoreMocks, createMockedConnectionString, createMockedKeyValue, sleepInMs, createMockedFeatureFlag } from "./utils/testHelper.js";
+import { mockAppConfigurationClientListConfigurationSettings, mockAppConfigurationClientListConfigurationSettingsWithStringStatus, mockAppConfigurationClientGetConfigurationSetting, restoreMocks, createMockedConnectionString, createMockedKeyValue, sleepInMs, createMockedFeatureFlag } from "./utils/testHelper.js";
 import * as uuid from "uuid";
 
 let mockedKVs: any[] = [];
@@ -572,6 +572,48 @@ describe("dynamic refresh feature flags", function () {
         expect(settings.get<any>("feature_management").feature_flags[0].id).eq("Beta");
         expect(settings.get<any>("feature_management").feature_flags[0].enabled).eq(false);
 
+    });
+
+    it("should refresh feature flags when page response status is string", async () => {
+        mockedKVs = [
+            createMockedFeatureFlag("Beta", { enabled: true })
+        ];
+        mockAppConfigurationClientListConfigurationSettingsWithStringStatus([mockedKVs], listKvCallback);
+        mockAppConfigurationClientGetConfigurationSetting(mockedKVs, getKvCallback);
+
+        const connectionString = createMockedConnectionString();
+        const settings = await load(connectionString, {
+            featureFlagOptions: {
+                enabled: true,
+                selectors: [{
+                    keyFilter: "Beta"
+                }],
+                refresh: {
+                    enabled: true,
+                    refreshIntervalInMs: 2000 // 2 seconds for quick test.
+                }
+            }
+        });
+        expect(listKvRequestCount).eq(2); // one listKv request for kvs and one listKv request for feature flags
+        expect(getKvRequestCount).eq(0);
+        expect(settings).not.undefined;
+        expect(settings.get<any>("feature_management").feature_flags[0].enabled).eq(true);
+
+        // change feature flag Beta to false
+        updateSetting(".appconfig.featureflag/Beta", JSON.stringify({
+            "id": "Beta",
+            "description": "",
+            "enabled": false,
+            "conditions": {
+                "client_filters": []
+            }
+        }));
+
+        await sleepInMs(2 * 1000 + 1);
+        await settings.refresh();
+        expect(listKvRequestCount).eq(4); // 2 + 2 more requests: one conditional request to detect change and one request to reload all feature flags
+        expect(getKvRequestCount).eq(0);
+        expect(settings.get<any>("feature_management").feature_flags[0].enabled).eq(false);
     });
 
     it("should refresh feature flags based on page etags, only on change", async () => {

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -63,7 +63,7 @@ function _filterKVs(unfilteredKvs: ConfigurationSetting[], listOptions: any) {
     });
 }
 
-function getMockedIterator(pages: ConfigurationSetting[][], kvs: ConfigurationSetting[], listOptions: any) {
+function getMockedIterator(pages: ConfigurationSetting[][], kvs: ConfigurationSetting[], listOptions: any, useStringStatus: boolean = false) {
     const mockIterator: AsyncIterableIterator<any> & { byPage(): AsyncIterableIterator<any> } = {
         [Symbol.asyncIterator](): AsyncIterableIterator<any> {
             kvs = _filterKVs(pages.flat(), listOptions);
@@ -95,7 +95,7 @@ function getMockedIterator(pages: ConfigurationSetting[][], kvs: ConfigurationSe
                             value: {
                                 items,
                                 etag,
-                                _response: { status: statusCode }
+                                _response: { status: useStringStatus ? `${statusCode}` : statusCode }
                             }
                         };
                     }
@@ -123,6 +123,18 @@ function mockAppConfigurationClientListConfigurationSettings(pages: Configuratio
 
         const kvs = _filterKVs(pages.flat(), listOptions);
         return getMockedIterator(pages, kvs, listOptions);
+    });
+}
+
+function mockAppConfigurationClientListConfigurationSettingsWithStringStatus(pages: ConfigurationSetting[][], customCallback?: (listOptions) => any) {
+
+    sinon.stub(AppConfigurationClient.prototype, "listConfigurationSettings").callsFake((listOptions) => {
+        if (customCallback) {
+            customCallback(listOptions);
+        }
+
+        const kvs = _filterKVs(pages.flat(), listOptions);
+        return getMockedIterator(pages, kvs, listOptions, true);
     });
 }
 
@@ -323,6 +335,7 @@ class HttpRequestHeadersPolicy {
 export {
     sinon,
     mockAppConfigurationClientListConfigurationSettings,
+    mockAppConfigurationClientListConfigurationSettingsWithStringStatus,
     mockAppConfigurationClientGetConfigurationSetting,
     mockAppConfigurationClientGetSnapshot,
     mockAppConfigurationClientListConfigurationSettingsForSnapshot,


### PR DESCRIPTION
### Summary

Feature-flag refresh change detection currently assumes page response status is numeric. In some runtime paths, status is returned as a string, which prevents detecting a valid 200 response and can leave feature flags stale.

Addresses issue #333 

### What changed

- Normalize page response status with Number(...) in refresh change detection
- Add regression test support for string status responses
- Add a dynamic refresh feature-flag test that reproduces and verifies the string-status scenario

### Why

This makes change detection robust across status value types and prevents false no-change outcomes when status is "200".

### Validation

Built test outputs
Ran refresh test suite for both ESM and CJS artifacts
All tests passed, including the new regression scenario